### PR TITLE
Redirect stderr

### DIFF
--- a/geonotebook/vis/geotrellis/server.py
+++ b/geonotebook/vis/geotrellis/server.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import numpy as np
+import os
 import rasterio
 import threading
 import sys
@@ -41,6 +42,10 @@ def make_tile_server(port, fn):
     '''
     app = Flask(__name__)
     http_server = WSGIServer(('', port), app)
+
+    f = open(os.devnull, "w")
+    # sys.stdout = f
+    sys.stderr = f
 
     def shutdown():
         time.sleep(0.5)


### PR DESCRIPTION
Redirect `stderr` to avoid echoing in the GeoNotebook.  Should work on top of geotrellis/geonotebook#1.