### PR TITLE
Fix: Layer Numbers

### DIFF
--- a/geonotebook/layers.py
+++ b/geonotebook/layers.py
@@ -246,6 +246,7 @@ class SimpleLayer(DataLayer):
     def query_params(self):
         return self.config.vis_server.get_params(
             self.name, self.data, **self.vis_options.serialize())
+
     def __repr__(self):
         return "<{}('{}')>".format(
             self.__class__.__name__, self.name.split("_")[0])
@@ -269,7 +270,8 @@ class InProcessTileLayer(DataLayer):
 
     @property
     def name(self):
-        return self._name
+        return "{}_{}".format(
+            self._name, hash(self.vis_options) + sys.maxsize + 1)
 
     @property
     def query_params(self):

--- a/geonotebook/vis/geotrellis/geotrellis.py
+++ b/geonotebook/vis/geotrellis/geotrellis.py
@@ -16,7 +16,7 @@ from .server import (rdd_server,
 from .render_methods import render_default_rdd
 
 logger = logging.getLogger('geotrellis-tile-server')
-# jupyterhub --no-ssl --Spawner.notebook_dir=/home/hadoop
+# jupyterhub --no-ssl --Spawner.notebook_dir=/home/hadoop/notebooks
 
 class GeoTrellisTileHandler(IPythonHandler):
 


### PR DESCRIPTION
`len(M.layers)` should now be equal to the current number of extant layers.  Connects locationtech-labs/geopyspark#223.