### PR TITLE
Overzooming and max zoom adjustment

### DIFF
--- a/geonotebook/kernel.py
+++ b/geonotebook/kernel.py
@@ -184,7 +184,7 @@ class Remote(object):
 
 
 class Geonotebook(object):
-    msg_types = ['get_protocol', 'set_center', 'add_annotation_from_client',
+    msg_types = ['get_protocol', 'set_center', 'set_zoom_range', 'add_annotation_from_client',
                  'get_map_state']
 
     _protocol = None
@@ -370,6 +370,21 @@ class Geonotebook(object):
         return self._remote.set_center(x, y, z)\
             .then(_set_center, self.rpc_error).catch(self.callback_error)
 
+    def set_zoom_range(self, min, max):
+        """Set the center of the map.
+
+        :param zoom:
+        :returns:
+        :rtype:
+
+        """
+        def _set_zoom_range(result):
+            self.min_zoom = result[0]
+            self.max_zoom = result[1]
+
+        return self._remote.set_zoom_range(min, max)\
+            .then(_set_zoom_range, self.rpc_error).catch(self.callback_error)
+
     def get_map_state(self):
         """Get the state of the map.
 
@@ -403,7 +418,7 @@ class Geonotebook(object):
 
         # HACK:  figure out a way to do this without so many conditionals
         if isinstance(data, RddRasterData):
-            name = data.name
+            name = data.name if name is None else name
 
             layer = InProcessTileLayer(name,
                                        self._remote,
@@ -413,7 +428,7 @@ class Geonotebook(object):
                                        **kwargs)
 
         elif isinstance(data, GeoTrellisCatalogLayerData):
-            name = "%s__%s" % (hash(data.catalog_uri), data.layer_name)
+            name = data.name if name is None else name
 
             layer = InProcessTileLayer(name,
                                        self._remote,

--- a/geonotebook/kernel.py
+++ b/geonotebook/kernel.py
@@ -184,8 +184,8 @@ class Remote(object):
 
 
 class Geonotebook(object):
-    msg_types = ['get_protocol', 'set_center', 'set_zoom_range', 'add_annotation_from_client',
-                 'get_map_state']
+    msg_types = ['get_protocol', 'set_center', 'set_zoom_range', 'set_max_zoom',
+                 'add_annotation_from_client', 'get_map_state']
 
     _protocol = None
     _remote = None
@@ -384,6 +384,20 @@ class Geonotebook(object):
 
         return self._remote.set_zoom_range(min, max)\
             .then(_set_zoom_range, self.rpc_error).catch(self.callback_error)
+
+    def set_max_zoom(self, max):
+        """Set the maximum allowable zoom level for the map.
+
+        :param max:
+        :returns:
+        :rtype:
+
+        """
+        def _set_max_zoom(result):
+            self.max_zoom = result
+
+        return self._remote.set_max_zoom(max)\
+            .then(_set_max_zoom, self.rpc_error).catch(self.callback_error)
 
     def get_map_state(self):
         """Get the state of the map.

--- a/geonotebook/layers.py
+++ b/geonotebook/layers.py
@@ -42,6 +42,7 @@ class GeonotebookLayer(object):
         self._expose_as = kwargs.pop("expose_as", None)
 
         self.vis_options = self.StyleOptions(**kwargs)
+
         self.can_subset = False
 
     def __repr__(self):

--- a/geonotebook/vis/geotrellis/geotrellis.py
+++ b/geonotebook/vis/geotrellis/geotrellis.py
@@ -10,7 +10,6 @@ from geonotebook.wrappers import (RddRasterData,
                                   GeoTrellisCatalogLayerData)
 from .server import (rdd_server,
                      catalog_layer_server,
-                     catalog_multilayer_server,
                      png_layer_server)
 
 from .render_methods import render_default_rdd
@@ -131,16 +130,21 @@ class GeoTrellis(object):
 
             args = (port_coordination,
                     data.value_reader,
-                    data.layer_name,
+                    data.layer_names,
+                    data.is_multi_layer,
                     data.key_type,
                     data.tile_type,
                     data.avroregistry,
+                    data.max_zoom,
                     render_tile)
-            if isinstance(data.layer_name, list):
-                t = threading.Thread(target=catalog_multilayer_server, args=args)
-            else:
-                t = threading.Thread(target=catalog_layer_server, args=args)
-            t.start()
+            # if isinstance(data.layer_name, list):
+            #     p = multiprocessing.Process(target=catalog_multilayer_server, args=args)
+            # else:
+            #     p = multiprocessing.Process(target=catalog_layer_server, args=args)
+            p = multiprocessing.Process(target=catalog_layer_server, args=args)
+            p.start()
+            # t = threading.Thread(target=catalog_layer_server, args=args)
+            # t.start()
         else:
             raise Exception("GeoTrellis vis server cannot handle data of type %s" % (type(data)))
 

--- a/geonotebook/vis/geotrellis/geotrellis.py
+++ b/geonotebook/vis/geotrellis/geotrellis.py
@@ -137,14 +137,9 @@ class GeoTrellis(object):
                     data.avroregistry,
                     data.max_zoom,
                     render_tile)
-            # if isinstance(data.layer_name, list):
-            #     p = multiprocessing.Process(target=catalog_multilayer_server, args=args)
-            # else:
-            #     p = multiprocessing.Process(target=catalog_layer_server, args=args)
-            p = multiprocessing.Process(target=catalog_layer_server, args=args)
-            p.start()
-            # t = threading.Thread(target=catalog_layer_server, args=args)
-            # t.start()
+
+            t = threading.Thread(target=catalog_layer_server, args=args)
+            t.start()
         else:
             raise Exception("GeoTrellis vis server cannot handle data of type %s" % (type(data)))
 

--- a/geonotebook/vis/geotrellis/render_methods.py
+++ b/geonotebook/vis/geotrellis/render_methods.py
@@ -45,7 +45,6 @@ def rgba_functions(color_map):
     for key in color_map:
         m[key] = hex_to_rgb(color_map[key])
 
-
     def r(v):
         if v in m:
             return m[v][0]

--- a/geonotebook/vis/geotrellis/server.py
+++ b/geonotebook/vis/geotrellis/server.py
@@ -30,7 +30,8 @@ def make_tile_server(port_coordination, fn):
     app = Flask(__name__)
     app.logger.disabled = True
     logging.getLogger('werkzeug').disabled = True
-    http_server = WSGIServer(('', port), app)
+    # http_server = WSGIServer(('', port), app)
+    http_server = None
 
     f = open(os.devnull, "w")
     # sys.stdout = f
@@ -137,18 +138,17 @@ def catalog_layer_server(port,
 
         if overzoom:
             # Figure out image crop bounds
-            dz = z - max_zoom
             dx = x - tx * math.pow(2, dz)
             dy = y - ty * math.pow(2, dz)
 
             (w, h) = image.size
 
-            tw = int(w / dz)
-            th = int(h / dz)
+            tw = int(w / math.pow(2, dz))
+            th = int(h / math.pow(2, dz))
             (x0, x1) = (tw * dx, tw * (dx + 1))
             (y0, y1) = (th * dy, th * (dy + 1))
-            image = image.crop(x0, y0, x1, y1)
-            image = image.resample((256,256))
+            image = image.crop((x0, y0, x1, y1))
+            image = image.resize((w, h))
 
         return respond_with_image(image)
 

--- a/geonotebook/vis/geotrellis/server.py
+++ b/geonotebook/vis/geotrellis/server.py
@@ -1,5 +1,6 @@
-import io
+import io, os
 import logging
+import math
 import numpy as np
 import os
 import rasterio
@@ -27,7 +28,9 @@ def make_tile_server(port_coordination, fn):
     that takes z, x, y as the tile route.
     '''
     app = Flask(__name__)
-    http_server = None
+    app.logger.disabled = True
+    logging.getLogger('werkzeug').disabled = True
+    http_server = WSGIServer(('', port), app)
 
     f = open(os.devnull, "w")
     # sys.stdout = f
@@ -84,53 +87,68 @@ def rdd_server(port, pyramid, render_tile):
 
     return make_tile_server(port, tile)
 
-def catalog_layer_server(port, value_reader, layer_name, key_type, tile_type, avroregistry, render_tile):
+def catalog_layer_server(port,
+                         value_reader,
+                         layer_names,
+                         is_multi_layer,
+                         key_type,
+                         tile_type,
+                         avroregistry,
+                         max_zoom,
+                         render_tile):
     from geopyspark.avroserializer import AvroSerializer
 
-    def tile(z, x, y):
-        tile = value_reader.readTile(key_type,
-                                     layer_name,
-                                     z,
-                                     x,
-                                     y,
-                                     "")
-        if not tile:
-            abort(404)
-
-        decoder = avroregistry._get_decoder(tile_type)
-        encoder = avroregistry._get_encoder(tile_type)
-
-        ser = AvroSerializer(tile._2(), decoder, encoder)
-        arr = ser.loads(tile._1())[0]['data']
-        image = render_tile(arr)
-
-        return respond_with_image(image)
-
-    return make_tile_server(port, tile)
-
-def catalog_multilayer_server(port, value_reader, layer_names, key_type, tile_type, avroregistry, render_tile):
-    from geopyspark.avroserializer import AvroSerializer
+    decoder = avroregistry._get_decoder(tile_type)
+    encoder = avroregistry._get_encoder(tile_type)
 
     def tile(z, x, y):
+        if z > max_zoom:
+            overzoom = True
+            dz = z - max_zoom
+            tz = max_zoom
+            tx = math.floor(x / math.pow(2, dz))
+            ty = math.floor(y / math.pow(2, dz))
+        else:
+            overzoom = False
+            tz = z
+            tx = x
+            ty = y
+
         tiles = []
-        decoder = avroregistry._get_decoder(tile_type)
-        encoder = avroregistry._get_encoder(tile_type)
-
         for layer_name in layer_names:
             value = value_reader.readTile(key_type,
                                           layer_name,
-                                          z,
-                                          x,
-                                          y,
+                                          tz,
+                                          tx,
+                                          ty,
                                           "")
             if not value:
                 abort(404)
 
             ser = AvroSerializer(value._2(), decoder, encoder)
             tile = ser.loads(value._1())[0]['data']
+
             tiles.append(tile)
 
-        image = render_tile(tiles)
+        if is_multi_layer:
+            image = render_tile(tiles)
+        else:
+            image = render_tile(tiles[0])
+
+        if overzoom:
+            # Figure out image crop bounds
+            dz = z - max_zoom
+            dx = x - tx * math.pow(2, dz)
+            dy = y - ty * math.pow(2, dz)
+
+            (w, h) = image.size
+
+            tw = int(w / dz)
+            th = int(h / dz)
+            (x0, x1) = (tw * dx, tw * (dx + 1))
+            (y0, y1) = (th * dy, th * (dy + 1))
+            image = image.crop(x0, y0, x1, y1)
+            image = image.resample((256,256))
 
         return respond_with_image(image)
 

--- a/geonotebook/vis/utils.py
+++ b/geonotebook/vis/utils.py
@@ -57,7 +57,7 @@ def discrete_colors(colormap, count):
 class RasterStyleOptions(object):
     def __init__(self, opacity=1.0, gamma=1.0, projection='EPSG:3857',
                  kernel_id=None, zIndex=None, colormap=None, interval=None,
-                 layer_type=None, attribution=None, **kwargs):
+                 max_zoom=18, layer_type=None, attribution=None, **kwargs):
 
         # self.vis_url = vis_url
         self.opacity = opacity
@@ -65,6 +65,7 @@ class RasterStyleOptions(object):
         self.gamma = gamma
         self.interval = interval
         self.colormap = None
+        self.max_zoom = max_zoom
         self.zIndex = zIndex
         self.kernel_id = kernel_id
         self.layer_type = layer_type
@@ -112,7 +113,8 @@ class RasterStyleOptions(object):
             'colormap': self.colormap,
             'kernel_id': self.kernel_id,
             'zIndex': self.zIndex,
-            'attribution': self.attribution
+            'attribution': self.attribution,
+            'max_zoom': self.max_zoom
         }
 
     def __hash__(self):
@@ -125,7 +127,8 @@ class RasterStyleOptions(object):
             tuple(tuple(c.items()) for c in self.colormap),
             self.kernel_id,
             self.zIndex,
-            self.attribution))
+            self.attribution.
+            self.max_zoom))
 
 
 class VectorStyleOptions(object):

--- a/geonotebook/vis/utils.py
+++ b/geonotebook/vis/utils.py
@@ -127,7 +127,7 @@ class RasterStyleOptions(object):
             tuple(tuple(c.items()) for c in self.colormap),
             self.kernel_id,
             self.zIndex,
-            self.attribution.
+            self.attribution,
             self.max_zoom))
 
 

--- a/js/src/map/base.js
+++ b/js/src/map/base.js
@@ -34,6 +34,7 @@ var color_counter = 0;
 const msg_types = [
   'get_protocol',
   'set_center',
+  'set_zoom_range',
   'debug',
   'add_layer',
   'update_layer',
@@ -66,6 +67,7 @@ const annotation_types = {
  *   * _init_map()
  *   * _resize(size)
  *   * _set_center(x, y, z)
+ *   * _set_zoom_range(min, max)
  *   * _add_annotation_layer(name)
  *   * _add_osm_layer(name, url, vis, query)
  *   * _add_wms_layer(name, url, vis, query)
@@ -109,6 +111,15 @@ class MapObject {
       throw new constants.InvalidParams('Invalid parameters sent to set_center!');
     }
     return this._set_center(x, y, z);
+  }
+
+  /**
+   * Set the zoom range of the map.
+   * @param {number} min The min zoom level
+   * @param {number} max The max zoom level
+   */
+  set_zoom_range (min, max) {
+    return this._set_zoom_range(min, max);
   }
 
   /**

--- a/js/src/map/base.js
+++ b/js/src/map/base.js
@@ -35,6 +35,7 @@ const msg_types = [
   'get_protocol',
   'set_center',
   'set_zoom_range',
+  'set_max_zoom',
   'debug',
   'add_layer',
   'update_layer',
@@ -68,6 +69,7 @@ const annotation_types = {
  *   * _resize(size)
  *   * _set_center(x, y, z)
  *   * _set_zoom_range(min, max)
+ *   * _set_max_zoom(max)
  *   * _add_annotation_layer(name)
  *   * _add_osm_layer(name, url, vis, query)
  *   * _add_wms_layer(name, url, vis, query)
@@ -120,6 +122,14 @@ class MapObject {
    */
   set_zoom_range (min, max) {
     return this._set_zoom_range(min, max);
+  }
+
+  /**
+   * Set the maximum zoom level of the map.
+   * @param {number} max The max zoom level
+   */
+  set_max_zoom (max) {
+    return this._set_max_zoom(max);
   }
 
   /**

--- a/js/src/map/geojs.js
+++ b/js/src/map/geojs.js
@@ -28,6 +28,11 @@ class GeoJSMap extends BaseMap {
     return [x, y, z];
   }
 
+  _set_zoom_range (min, max) {
+    this.geojsmap.zoomRange({min: min, max: max});
+    return [min, max];
+  }
+
   _add_annotation_layer (name) {
     var layer = this.geojsmap.createLayer('annotation', {
       annotations: ['rectangle', 'point', 'polygon']
@@ -55,6 +60,10 @@ class GeoJSMap extends BaseMap {
     if (vis.attribution) {
       opts.attribution = vis.attribution;
     }
+    if(vis.maxZoom) {
+      opts.maxZoom = vis.maxZoom;
+    }
+
     var osm = this.geojsmap.createLayer('osm', opts);
 
     osm.name(name);
@@ -67,10 +76,13 @@ class GeoJSMap extends BaseMap {
   }
 
   _add_tiled_layer (name, url, vis, query) {
-    var layer = this.geojsmap.createLayer('osm', {
-      attribution: null,
-      keepLower: false
-    });
+    var opts = { attribution: null, keepLower: false };
+    if(vis.max_zoom) {
+      opts.maxLevel = vis.max_zoom;
+    }
+    console.log(opts.maxLevel);
+
+    var layer = this.geojsmap.createLayer('osm', opts);
     var params = '';
 
     if ($.param(query)) {
@@ -80,7 +92,7 @@ class GeoJSMap extends BaseMap {
     layer.name(name);
     layer.url((x, y, z) => `${url}/${x}/${y}/${z}.png${params}`);
 
-      // make sure zindex is explicitly set
+    // make sure zindex is explicitly set
     this._set_layer_zindex(layer, vis['zIndex']);
 
     return layer;
@@ -89,10 +101,12 @@ class GeoJSMap extends BaseMap {
   _add_wms_layer (name, url, vis, query) {
     var projection = query['projection'] || 'EPSG:3857';
 
-    var wms = this.geojsmap.createLayer('osm', {
-      keepLower: false,
-      attribution: null
-    });
+    var opts = { attribution: null, keepLower: false };
+    if(vis.maxZoom) {
+      opts.maxZoom = vis.maxZoom;
+    }
+
+    var wms = this.geojsmap.createLayer('osm', opts);
 
       // make sure zindex is explicitly set
     this._set_layer_zindex(wms, vis['zIndex']);

--- a/js/src/map/geojs.js
+++ b/js/src/map/geojs.js
@@ -33,6 +33,11 @@ class GeoJSMap extends BaseMap {
     return [min, max];
   }
 
+  _set_max_zoom (max) {
+    this.geojsmap.zoomRange({max: max});
+    return [max];
+  }
+
   _add_annotation_layer (name) {
     var layer = this.geojsmap.createLayer('annotation', {
       annotations: ['rectangle', 'point', 'polygon']


### PR DESCRIPTION
Previously, the GeoNotebook map interface was constrained to zoom levels less than or equal to 16.  We can now adjust the range of permissible zoom levels using a statement of the form `M.set_zoom_range(0,22)`.  One may also use `M.set_max_zoom(22)`.  Now, `M.set_center` can utilize zoom values up to 22.

This PR also adds functionality for overzooming.

This PR fixes #4 