### PR TITLE
Add facilities for TMS-served data

### DIFF
--- a/geonotebook/kernel.py
+++ b/geonotebook/kernel.py
@@ -24,6 +24,7 @@ from .utils import get_kernel_id
 from .wrappers import (RddRasterData,
                        GeoTrellisCatalogLayerData,
                        RasterData,
+                       TMSRasterData,
                        RasterDataCollection,
                        VectorData,
                        GeoJsonData)
@@ -414,6 +415,16 @@ class Geonotebook(object):
 
         elif isinstance(data, GeoTrellisCatalogLayerData):
             name = "%s__%s" % (hash(data.catalog_uri), data.layer_name)
+
+            layer = InProcessTileLayer(name,
+                                       self._remote,
+                                       data=data,
+                                       inproc_server_states=self._inproc_server_states,
+                                       vis_url=vis_url,
+                                       **kwargs)
+
+        elif isinstance(data, TMSRasterData):
+            name = data.name
 
             layer = InProcessTileLayer(name,
                                        self._remote,

--- a/geonotebook/wrappers/__init__.py
+++ b/geonotebook/wrappers/__init__.py
@@ -1,4 +1,4 @@
-from .raster import RddRasterData, RasterData, RasterDataCollection, GeoTrellisCatalogLayerData
+from .raster import RddRasterData, RasterData, TMSRasterData, RasterDataCollection, GeoTrellisCatalogLayerData
 from .vector import VectorData, GeoJsonData
 
 
@@ -7,4 +7,5 @@ __all__ = ('RasterData',
            'VectorData',
            'GeoJsonData',
            'RddRasterData',
+           'TMSRasterData',
            'GeoTrellisCatalogLayerData')

--- a/geonotebook/wrappers/raster.py
+++ b/geonotebook/wrappers/raster.py
@@ -24,6 +24,15 @@ class RddRasterData(object):
         else:
             self.name = name
 
+class TMSRasterData(object):
+    def __init__(self, tms, name=None):
+        self.tms = tms
+
+        if not name:
+            self.name = str(hash(tms))
+        else:
+            self.name = name
+
 class GeoTrellisCatalogLayerData(object):
 
     def __init__(self,


### PR DESCRIPTION
This PR adds the `TMSRasterData` wrapper to enable layers to be added which are backed by a TMS server.  Changes are made to the GeoTrellis viz server to accommodate this new wrapper.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>