### PR TITLE
Eliminated the use of PngRDD

### DIFF
--- a/geonotebook/kernel.py
+++ b/geonotebook/kernel.py
@@ -21,8 +21,7 @@ from .layers import (AnnotationLayer,
                      VectorLayer)
 
 from .utils import get_kernel_id
-from .wrappers import (RddRasterData,
-                       GeoTrellisCatalogLayerData,
+from .wrappers import (GeoTrellisCatalogLayerData,
                        RasterData,
                        TMSRasterData,
                        RasterDataCollection,
@@ -403,17 +402,7 @@ class Geonotebook(object):
             kwargs['zIndex'] = len(self.layers)
 
         # HACK:  figure out a way to do this without so many conditionals
-        if isinstance(data, RddRasterData):
-            name = data.name
-
-            layer = InProcessTileLayer(name,
-                                       self._remote,
-                                       data=data,
-                                       inproc_server_states=self._inproc_server_states,
-                                       vis_url=vis_url,
-                                       **kwargs)
-
-        elif isinstance(data, GeoTrellisCatalogLayerData):
+        if isinstance(data, GeoTrellisCatalogLayerData):
             name = "%s__%s" % (hash(data.catalog_uri), data.layer_name)
 
             layer = InProcessTileLayer(name,

--- a/geonotebook/vis/geotrellis/server.py
+++ b/geonotebook/vis/geotrellis/server.py
@@ -129,32 +129,3 @@ def catalog_multilayer_server(port, value_reader, layer_names, key_type, render_
 
     return make_tile_server(port, tile)
 
-def png_layer_server(port, png):
-    def tile(z, x, y):
-
-        # fetch data
-        try:
-            img = png.lookup(x, y, z)
-        except:
-            img = None
-
-        if img == None or len(img) == 0:
-            if png.debug:
-                image = Image.new('RGBA', (256,256))
-                draw = ImageDraw.Draw(image)
-                draw.rectangle([0, 0, 255, 255], outline=(255,0,0,255))
-                draw.line([(0,0),(255,255)], fill=(255,0,0,255))
-                draw.line([(0,255),(255,0)], fill=(255,0,0,255))
-                draw.text((136,122), str(x) + ', ' + str(y) + ', ' + str(zoom), fill=(255,0,0,255))
-                del draw
-                bio = io.BytesIO()
-                image.save(bio, 'PNG')
-                img = [bio.getvalue()]
-            else:
-                abort(404)
-
-        response = make_response(img[0])
-        response.headers['Content-Type'] = 'image/png'
-        return response
-
-    return make_tile_server(port, tile)

--- a/geonotebook/wrappers/__init__.py
+++ b/geonotebook/wrappers/__init__.py
@@ -1,4 +1,4 @@
-from .raster import RddRasterData, RasterData, TMSRasterData, RasterDataCollection, GeoTrellisCatalogLayerData
+from .raster import RasterData, TMSRasterData, RasterDataCollection, GeoTrellisCatalogLayerData
 from .vector import VectorData, GeoJsonData
 
 
@@ -6,6 +6,5 @@ __all__ = ('RasterData',
            'RasterDataCollection',
            'VectorData',
            'GeoJsonData',
-           'RddRasterData',
            'TMSRasterData',
            'GeoTrellisCatalogLayerData')

--- a/geonotebook/wrappers/raster.py
+++ b/geonotebook/wrappers/raster.py
@@ -8,22 +8,6 @@ import pkg_resources as pr
 
 from shapely.geometry import Polygon
 
-class RddRasterData(object):
-
-    def __init__(self, rdd, name=None):
-        from geopyspark.geotrellis.layer import RasterLayer, TiledRasterLayer
-        from geopyspark.geotrellis.render import PngRDD
-
-        if not (isinstance(rdd, RasterLayer) or isinstance(rdd, TiledRasterLayer) or isinstance(rdd, PngRDD)):
-            raise TypeError("Expected a RasterLayer, TiledRasterLayer, or PngRDD")
-
-        self.rdd = rdd
-
-        if not name:
-            self.name = str(hash(rdd))
-        else:
-            self.name = name
-
 class TMSRasterData(object):
     def __init__(self, tms, name=None):
         self.tms = tms


### PR DESCRIPTION
As we've been moving toward a TMS-based system for serving raster layers, the use of PngRDD is no longer needed.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>