### PR TITLE
Use proper interface for TMS objects

### DIFF
--- a/geonotebook/vis/geotrellis/geotrellis.py
+++ b/geonotebook/vis/geotrellis/geotrellis.py
@@ -117,11 +117,10 @@ class GeoTrellis(object):
         # TODO: refactor this to different methods?
         if isinstance(data, TMSRasterData):
             tms = data.tms
-            server = tms.server
-            server.setHandshake(port_coordination['handshake'])
-            server.bind("0.0.0.0")
-            port_coordination['port'] = server.port()
-            inproc_server_states['geotrellis']['server'][name] = server
+            tms.set_handshake(port_coordination['handshake'])
+            tms.bind()
+            port_coordination['port'] = tms.port
+            inproc_server_states['geotrellis']['server'][name] = tms
         elif isinstance(data, GeoTrellisCatalogLayerData):
             render_tile = kwargs.pop('render_tile', None)
             if render_tile is None:


### PR DESCRIPTION
When TMS functionality was written into the GT vis server, we directly interacted with the Scala object's interface.  The python TMS class has picked up a more fleshed out interface as of locationtech-labs/geopyspark#424, and so this interface should be used in the GT vis server.  Note, however, that there was a bug fix in locationtech-labs/geopyspark#454 that is required for the present PR to function properly.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>