### PR TITLE
Allow jupyter notebook to run on arbitrary port

### DIFF
--- a/config/geonotebook.ini
+++ b/config/geonotebook.ini
@@ -8,7 +8,6 @@ password = geoserver
 url = http://127.0.0.1:8080/geoserver
 
 [ktile]
-url = http://127.0.0.1:8888/ktile
 default_cache = ktile_default_cache
 
 [ktile_default_cache]

--- a/geonotebook/__init__.py
+++ b/geonotebook/__init__.py
@@ -5,7 +5,6 @@ import pkg_resources
 
 from .config import Config
 
-
 def _jupyter_server_extension_paths():
     return [{
         "module": "geonotebook"
@@ -66,7 +65,7 @@ def load_jupyter_server_extension(nbapp):
     webapp = nbapp.web_app
     conf = Config()
 
-    conf.vis_server.initialize_webapp(conf, webapp)
+    conf.vis_server.initialize_webapp(conf, webapp, log=nbapp.log, port=nbapp.port)
 
     base_url = webapp.settings['base_url']
 

--- a/geonotebook/vis/ktile/ktile.py
+++ b/geonotebook/vis/ktile/ktile.py
@@ -84,9 +84,8 @@ class KtileConfigManager(MutableMapping):
 # different contexts!
 
 class Ktile(object):
-    def __init__(self, config, url=None, default_cache=None):
+    def __init__(self, config, default_cache=None):
         self.config = config
-        self.base_url = url
         self.default_cache_section = default_cache
 
     @property
@@ -114,9 +113,6 @@ class Ktile(object):
         else:
             raise RuntimeError("Unknown error during kernel registration" if 'err_msg' not in resp else resp['err_msg'])
 
-        # requests.post("{}/{}".format(self.base_url, kernel_id))
-        # Error checking on response!
-
     def shutdown_kernel(self, kernel):
         kernel_id = get_kernel_id(kernel)
         resp = self.webapp_comm({
@@ -129,9 +125,7 @@ class Ktile(object):
         else:
             raise RuntimeError("Unknown error during kernel delete" if 'err_msg' not in resp else resp['err_msg'])
 
-        #requests.delete("{}/{}".format(self.base_url, kernel_id))
-
-    # This function is caleld inside the tornado web app
+    # This function is called inside the tornado web app
     # from jupyter_load_server_extensions
     def initialize_webapp(self, config, webapp, log=None, port=None):
         base_url = webapp.settings['base_url']
@@ -315,19 +309,3 @@ class Ktile(object):
             raise RuntimeError("KTile.ingest() failed with error:\n\n{}".format(resp['err_msg']))
 
         return base_url
-
-        # r = requests.post(base_url, json={
-        #     "provider": {
-        #         "class": "geonotebook.vis.ktile.provider:MapnikPythonProvider",
-        #         "kwargs": options
-        #     }
-        #     # NB: Other KTile layer options could go here
-        #     #     See: http://tilestache.org/doc/#layers
-        # })
-
-        # if r.status_code == 200:
-        #     return base_url
-        # else:
-        #     raise RuntimeError(
-        #         "KTile.ingest() returned {} error:\n\n{}".format(
-        #             r.status_code, ''.join(r.json()['error'])))


### PR DESCRIPTION
Previously, it was required to specify a "base_url" in the geonotebook.ini file which essentially set the port number that the Ktile vis server would look for the Jupyter notebook instance on.  This meant that notebook instances launched from JupyterHub would fail to display layer data.

A mechanism was needed to determine the port on which the Tornado webapp was running.  This ended up being the use of a ZeroMQ socket plugged into the Tornado event loop.  Now, it is possible to make queries on port 14253 to determine the port number of the running process.

Along the way, I used this 0MQ system to eliminate the use of Python's `requests` library in the ktile server.  This ought to allow for a simplified handler structure in the webapp, and should remove a layer of indirection.

On the downside, this mod won't allow multiple users on the same system to run concurrently due to contention for the port that 0MQ is listening on.